### PR TITLE
Fix blobsaver script in dirs with spaces

### DIFF
--- a/dist/linux/blobsaver
+++ b/dist/linux/blobsaver
@@ -26,4 +26,4 @@ else
 fi
 # find the directory this bash script is in (https://stackoverflow.com/a/246128/)
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
-$JAVA -jar $DIR/blobsaver.jar "$@"
+$JAVA -jar "$DIR/blobsaver.jar" "$@"

--- a/dist/linux/blobsaver
+++ b/dist/linux/blobsaver
@@ -26,4 +26,4 @@ else
 fi
 # find the directory this bash script is in (https://stackoverflow.com/a/246128/)
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
-$JAVA -jar "$DIR/blobsaver.jar" "$@"
+"$JAVA" -jar "$DIR/blobsaver.jar" "$@"


### PR DESCRIPTION
Currently, the blobsaver script on Linux fails to run in a directory with spaces, since the variable in the bash script are not quoted. This PR quotes said variables and allows running the script in a directory that contains spaces in the name.