### PR TITLE
Add ability to save blobs to SHSH Host and TSS Saver

### DIFF
--- a/src/main/java/airsquared/blobsaver/app/Controller.java
+++ b/src/main/java/airsquared/blobsaver/app/Controller.java
@@ -78,6 +78,12 @@ public class Controller {
         backgroundSettingsMenu.textProperty().bind(Bindings.when(backgroundSettingsButton.selectedProperty())
                 .then("Hide Background Settings").otherwise("Show Background Settings"));
         backgroundSettingsMenu.setOnAction(e -> backgroundSettingsButton.fire());
+        allSignedVersionsCheckBox.selectedProperty().addListener((observable, oldValue, newValue) -> {
+            if (!newValue) {
+                saveToTSSSaverCheckBox.setSelected(false);
+                saveToSHSHHostCheckBox.setSelected(false);
+            }
+        });
         switch (Prefs.getDarkMode()) {
             case DISABLED -> darkDisabled.setSelected(true);
             case SYNC_WITH_OS -> darkSync.setSelected(true);

--- a/src/main/java/airsquared/blobsaver/app/Controller.java
+++ b/src/main/java/airsquared/blobsaver/app/Controller.java
@@ -19,7 +19,6 @@
 package airsquared.blobsaver.app;
 
 import airsquared.blobsaver.app.natives.Libirecovery;
-import com.google.gson.Gson;
 import com.sun.jna.Platform;
 import com.sun.jna.ptr.PointerByReference;
 import de.jangassen.MenuToolkit;
@@ -42,9 +41,7 @@ import javafx.stage.FileChooser;
 import javafx.stage.Modality;
 
 import java.io.File;
-import java.net.http.HttpResponse;
 import java.util.Locale;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 @SuppressWarnings("TextBlockMigration")
@@ -635,7 +632,9 @@ public class Controller {
         TSS.Builder builder = new TSS.Builder()
                 .setDevice(identifierCheckBox.isSelected() ?
                         identifierField.getText() : Devices.modelToIdentifier(deviceModelChoiceBox.getValue()))
-                .setEcid(ecidField.getText()).setSavePath(pathField.getText());
+                .setEcid(ecidField.getText()).setSavePath(pathField.getText())
+                .saveToTSSSaver(saveToTSSSaverCheckBox.isSelected())
+                .saveToSHSHHost(saveToSHSHHostCheckBox.isSelected());
         if (!boardConfigField.isDisabled()) {
             builder.setBoardConfig(boardConfigField.getText());
         }
@@ -662,59 +661,11 @@ public class Controller {
 
         tss.setOnScheduled(event -> runningAlert.show());
         tss.setOnSucceeded(event -> {
-            String tssValue = tss.getValue();
-            Map responseBodyMapped = null;
-            if (saveToTSSSaverCheckBox.isSelected()) {
-                try {
-                    HttpResponse<String> response = tss.saveBlobsTSSSaver();
-                    System.out.println(response.body());
-                    Gson gson = new Gson();
-                    responseBodyMapped = gson.fromJson(response.body(), Map.class);
-                    // if we can get the URL from the JSON Response
-                    // include it in the tssValue
-                    if (responseBodyMapped.containsKey("url")) {
-                        tssValue = tss.getValue() + "\nAlso saved blobs online to: " + responseBodyMapped.get("url");
-                    } else {
-                        tssValue = tss.getValue() + "\nTried saving blobs online to TSS Saver but got following Error(s): " + responseBodyMapped.get("errors").toString();
-                    }
-                } catch (Exception e) {
-                    tssValue = (tss.getValue() + "Error encountered while trying to save blobs online: " + e.getMessage());
-                }
-            }
-
-            if (saveToSHSHHostCheckBox.isSelected()) {
-                try {
-                    HttpResponse<String> SHSHHostResponse = tss.saveBlobsSHSHHost();
-                    System.out.println("shsh host code: " + SHSHHostResponse.statusCode());
-                    System.out.println("shsh host body: " + SHSHHostResponse.body());
-                    tssValue += "\nAlso saved blobs to SHSH Host";
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-            }
-            final String tssValueFinal = tssValue;
             runningAlert.close();
-
-            Alert alert = null;
-            ButtonType openURLButton = new ButtonType("Open URL");
-            ButtonType customOK = new ButtonType("OK", ButtonBar.ButtonData.CANCEL_CLOSE);
-            // if the tss saver url is available, include it in the alert.
-            if (responseBodyMapped != null && responseBodyMapped.containsKey("url")) {
-                alert = new Alert(Alert.AlertType.INFORMATION, tssValueFinal, openURLButton, customOK);
-            } else {
-                alert = new Alert(Alert.AlertType.INFORMATION, tssValueFinal, customOK);
-            }
-
-            ((Button) alert.getDialogPane().lookupButton(customOK)).setDefaultButton(true); // set 'ok' as the default button
+            Alert alert = new Alert(Alert.AlertType.INFORMATION, tss.getValue());
             alert.setHeaderText("Success!");
-            alert.setContentText(tssValueFinal);
-            System.out.println("text: " + tssValueFinal);
             alert.showAndWait();
-            if (alert.getResult() == openURLButton) {
-                Utils.openURL(responseBodyMapped.get("url").toString());
-            }
         });
-
         tss.setOnFailed(event -> {
             runningAlert.close();
             tss.getException().printStackTrace();

--- a/src/main/java/airsquared/blobsaver/app/Network.java
+++ b/src/main/java/airsquared/blobsaver/app/Network.java
@@ -1,0 +1,53 @@
+package airsquared.blobsaver.app;
+
+import com.google.gson.Gson;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+public class Network {
+
+    // one instance, reuse
+    private static final HttpClient httpClient = HttpClient.newBuilder()
+            .version(HttpClient.Version.HTTP_2)
+            .build();
+
+    // Performs a POST Request with the specified URL and Parameters
+    public static HttpResponse<String> makePOSTRequest(String url, Map<Object, Object> parameters, Map<String, String> headers, boolean convertParamtersToJSON) throws IOException, InterruptedException {
+
+        // convert Arguments to JSON (and use them if convertParametersToJSON is true)
+        Gson gson = new Gson();
+        String JSONParameters = gson.toJson(parameters);
+
+        HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+                .POST(convertParamtersToJSON ? BodyPublishers.ofString(JSONParameters) : buildFormDataFromMap(parameters))
+                .uri(URI.create(url));
+
+        for (Map.Entry<String, String> entry : headers.entrySet())
+            requestBuilder.header(entry.getKey(), entry.getValue());
+
+        HttpRequest request = requestBuilder.build();
+        return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+    }
+
+
+    private static HttpRequest.BodyPublisher buildFormDataFromMap(Map<Object, Object> data) {
+        var builder = new StringBuilder();
+        for (Map.Entry<Object, Object> entry : data.entrySet()) {
+            if (builder.length() > 0) {
+                builder.append("&");
+            }
+            builder.append(URLEncoder.encode(entry.getKey().toString(), StandardCharsets.UTF_8));
+            builder.append("=");
+            builder.append(URLEncoder.encode(entry.getValue().toString(), StandardCharsets.UTF_8));
+        }
+        return HttpRequest.BodyPublishers.ofString(builder.toString());
+    }
+}

--- a/src/main/java/airsquared/blobsaver/app/TSS.java
+++ b/src/main/java/airsquared/blobsaver/app/TSS.java
@@ -140,6 +140,9 @@ public class TSS extends Task<String> {
         if (!deviceIdentifier.contains(",") || !hasCorrectIdentifierPrefix) {
             throw new TSSException("\"" + deviceIdentifier + "\" is not a valid identifier", false);
         }
+        if (boardConfig == null && Devices.doesRequireBoardConfig(deviceIdentifier)) {
+            throw new TSSException("A board configuration is required for this device.", false);
+        }
         if (manualIpswURL != null) { // check URL
             try {
                 if (!ipswURLMatcher.reset(manualIpswURL).matches()) {
@@ -371,13 +374,17 @@ public class TSS extends Task<String> {
         @SuppressWarnings("rawtypes") Map responseBody = new Gson().fromJson(response.body(), Map.class);
 
         if (responseBody.containsKey("errors")) {
-            responseBuilder.append("Error encountered while trying to save blobs TSSSaver: ").append(responseBody.get("errors"));
+            responseBuilder.append("Error encountered while trying to save blobs to TSSSaver: ").append(responseBody.get("errors"));
         } else {
             responseBuilder.append("Also saved blobs online to TSS Saver.");
         }
     }
 
     private void saveBlobsSHSHHost(StringBuilder responseBuilder) {
+        if (saveToTSSSaver) {
+            responseBuilder.append("\n");
+        }
+
         Map<Object, Object> deviceParameters = new HashMap<>();
 
         deviceParameters.put("ecid", ecid);
@@ -409,6 +416,12 @@ public class TSS extends Task<String> {
         }
         System.out.println(response.body());
 
-        responseBuilder.append("Also saved blobs online to SHSH Host.");
+        @SuppressWarnings("rawtypes") Map responseBody = new Gson().fromJson(response.body(), Map.class);
+
+        if (responseBody.get("code").equals((double) 0)) {
+            responseBuilder.append("Also saved blobs online to SHSH Host.");
+        } else {
+            responseBuilder.append("Error encountered while trying to save blobs to SHSH Host: ").append(responseBody.get("message"));
+        }
     }
 }

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -8,4 +8,5 @@ open module airsquared.blobsaver {
     requires nsmenufx;
     requires com.google.gson;
     requires org.apache.commons.compress;
+    requires java.net.http;
 }

--- a/src/main/resources/airsquared/blobsaver/app/blobsaver.fxml
+++ b/src/main/resources/airsquared/blobsaver/app/blobsaver.fxml
@@ -262,6 +262,18 @@
             </Label>
         </HBox>
         <Region VBox.vgrow="ALWAYS"/>
+        <CheckBox fx:id="saveToTSSSaverCheckBox" prefWidth="Infinity" maxWidth="Infinity"
+                  mnemonicParsing="false" text="Also save to TSS Saver" selected="true">
+            <VBox.margin>
+                <Insets left="10.0" top="5.0"/>
+            </VBox.margin>
+        </CheckBox>
+        <CheckBox fx:id="saveToSHSHHostCheckBox" prefWidth="Infinity" maxWidth="Infinity"
+                  mnemonicParsing="false" text="Also save to SHSH Host" selected="true">
+            <VBox.margin>
+                <Insets left="10.0" top="5.0"/>
+            </VBox.margin>
+        </CheckBox>
         <Button maxWidth="Infinity" mnemonicParsing="false" onAction="#goButtonHandler" prefWidth="Infinity" text="Go"
                 defaultButton="true" disable="${backgroundSettingsButton.selected}">
             <VBox.margin>

--- a/src/main/resources/airsquared/blobsaver/app/blobsaver.fxml
+++ b/src/main/resources/airsquared/blobsaver/app/blobsaver.fxml
@@ -262,12 +262,14 @@
             </Label>
         </HBox>
         <Region VBox.vgrow="ALWAYS"/>
-        <CheckBox fx:id="saveToTSSSaverCheckBox" mnemonicParsing="false" text="Also save to TSS Saver">
+        <CheckBox fx:id="saveToTSSSaverCheckBox" mnemonicParsing="false" text="Also save to TSS Saver"
+                  disable="${!allSignedVersionsCheckBox.selected}">
             <VBox.margin>
                 <Insets left="10.0" top="5.0"/>
             </VBox.margin>
         </CheckBox>
-        <CheckBox fx:id="saveToSHSHHostCheckBox" mnemonicParsing="false" text="Also save to SHSH Host">
+        <CheckBox fx:id="saveToSHSHHostCheckBox" mnemonicParsing="false" text="Also save to SHSH Host"
+                  disable="${!allSignedVersionsCheckBox.selected}">
             <VBox.margin>
                 <Insets left="10.0" top="5.0"/>
             </VBox.margin>

--- a/src/main/resources/airsquared/blobsaver/app/blobsaver.fxml
+++ b/src/main/resources/airsquared/blobsaver/app/blobsaver.fxml
@@ -262,14 +262,12 @@
             </Label>
         </HBox>
         <Region VBox.vgrow="ALWAYS"/>
-        <CheckBox fx:id="saveToTSSSaverCheckBox" prefWidth="Infinity" maxWidth="Infinity"
-                  mnemonicParsing="false" text="Also save to TSS Saver" selected="true">
+        <CheckBox fx:id="saveToTSSSaverCheckBox" mnemonicParsing="false" text="Also save to TSS Saver">
             <VBox.margin>
                 <Insets left="10.0" top="5.0"/>
             </VBox.margin>
         </CheckBox>
-        <CheckBox fx:id="saveToSHSHHostCheckBox" prefWidth="Infinity" maxWidth="Infinity"
-                  mnemonicParsing="false" text="Also save to SHSH Host" selected="true">
+        <CheckBox fx:id="saveToSHSHHostCheckBox" mnemonicParsing="false" text="Also save to SHSH Host">
             <VBox.margin>
                 <Insets left="10.0" top="5.0"/>
             </VBox.margin>


### PR DESCRIPTION
This pull requests makes it possible to save blobs to TSS Saver and SHSH Host with the device information in Blobsaver
TLDR of how it works: a HTTP POST Request is made to https://tsssaver.1conan.com/v2/api/save.php for TSS Saver and https://api.arx8x.net/shsh3/ for SHSH Host, with the parameters being `ecid, deviceIdentifier, and boardConfig`, If the generator and APNonce information is present in the Blobsaver app, then those are also included in the request parameters.

How the Main Menu looks now (Added a toggle for saving to TSS Saver and SHSH Host, on by default): 
![image](https://user-images.githubusercontent.com/48022799/155977703-b0d85137-f649-403e-8636-5b9441d4571b.png)

If the "Save to TSS Saver" toggle is turned on and the program successfully saves blobs, then the "Successfully saved blobs" Pop up now looks like this 

![image](https://user-images.githubusercontent.com/48022799/151674365-4c7e2898-bb37-47c8-9ba9-7c718c69592b.png)
