### PR TITLE
added ${Name} as variable for save path (CLI only)

### DIFF
--- a/src/main/java/airsquared/blobsaver/app/Background.java
+++ b/src/main/java/airsquared/blobsaver/app/Background.java
@@ -280,7 +280,8 @@ class Background {
     }
 
     public static void saveBlobs(Prefs.SavedDevice savedDevice) {
-        TSS.Builder builder = new TSS.Builder().setDevice(savedDevice.getIdentifier())
+        TSS.Builder builder = new TSS.Builder().setName(savedDevice.getName())
+                .setDevice(savedDevice.getIdentifier())
                 .setEcid(savedDevice.getEcid()).setSavePath(savedDevice.getSavePath())
                 .setIncludeBetas(savedDevice.doesIncludeBetas());
         savedDevice.getBoardConfig().ifPresent(builder::setBoardConfig);

--- a/src/main/java/airsquared/blobsaver/app/CLI.java
+++ b/src/main/java/airsquared/blobsaver/app/CLI.java
@@ -93,7 +93,7 @@ public class CLI implements Callable<Void> {
 
     @Option(names = "--save-path", paramLabel = "<path>",
             description = "Directory to save blobs in. Can use the following variables: " +
-                    "$${DeviceIdentifier}, $${BoardConfig}, $${APNonce}, $${Generator}, $${DeviceModel}, $${ECID}, $${FullVersionString}, $${BuildID}, and $${MajorVersion}.")
+                    "$${DeviceIdentifier}, $${BoardConfig}, $${APNonce}, $${Generator}, $${DeviceModel}, $${ECID}, $${FullVersionString}, $${BuildID}, $${MajorVersion} and $${Name} (if using a saved device).")
     File savePath;
 
     @ArgGroup

--- a/src/main/java/airsquared/blobsaver/app/Controller.java
+++ b/src/main/java/airsquared/blobsaver/app/Controller.java
@@ -57,6 +57,7 @@ public class Controller {
 
     @FXML private TextField ecidField, boardConfigField, apnonceField, generatorField, versionField, identifierField,
             pathField, ipswField;
+    private String deviceName;
 
     @FXML private CheckBox apnonceCheckBox, allSignedVersionsCheckBox, identifierCheckBox, betaCheckBox,
             manualURLCheckBox, saveToTSSSaverCheckBox, saveToSHSHHostCheckBox;
@@ -204,6 +205,7 @@ public class Controller {
         }
         deleteDeviceMenu.setText("Remove \"" + savedDevice + "\"");
 
+        deviceName = savedDevice.getName();
         ecidField.setText(savedDevice.getEcid());
         pathField.setText(savedDevice.getSavePath());
         if (!betaCheckBox.isDisabled()) {
@@ -324,7 +326,8 @@ public class Controller {
     public void locationHelp() {
         ButtonType openURL = new ButtonType("Open URL");
         Alert alert = new Alert(Alert.AlertType.INFORMATION,
-                "You can use the following variables which will be automatically replaced by their respective values: ${DeviceIdentifier}, ${BoardConfig}, ${APNonce}, ${Generator}, ${DeviceModel}, ${ECID}, ${FullVersionString}, ${BuildID}, and ${MajorVersion}." +
+                "You can use the following variables which will be automatically replaced by their respective values: ${DeviceIdentifier}, ${BoardConfig}, ${APNonce}, ${Generator}, ${DeviceModel}, ${ECID}, ${FullVersionString}, ${BuildID} and ${MajorVersion}." +
+                        "\nIf using a saved device you can also use ${Name}." +
                         "\n\nExamples: /Users/airsquared/Blobs/${DeviceModel}/${MajorVersion}" +
                         "\n/Users/airsquared/Blobs/${DeviceIdentifier}/${MajorVersion}/${FullVersionString}\n\n" +
                         "Click \"Open URL\" to see how to automatically upload blobs you save to the cloud.", openURL, ButtonType.OK);
@@ -655,6 +658,7 @@ public class Controller {
 
     private TSS createTSS(String runningAlertTitle) {
         TSS.Builder builder = new TSS.Builder()
+                .setName(deviceName)
                 .setDevice(identifierCheckBox.isSelected() ?
                         identifierField.getText() : Devices.modelToIdentifier(deviceModelChoiceBox.getValue()))
                 .setEcid(ecidField.getText()).setSavePath(pathField.getText())

--- a/src/main/java/airsquared/blobsaver/app/Controller.java
+++ b/src/main/java/airsquared/blobsaver/app/Controller.java
@@ -665,6 +665,13 @@ public class Controller {
                 .setIncludeBetas(betaCheckBox.isSelected())
                 .saveToTSSSaver(saveToTSSSaverCheckBox.isSelected())
                 .saveToSHSHHost(saveToSHSHHostCheckBox.isSelected());
+        if (pathField.getText().contains("${Name}") && deviceName == null) {
+            final Alert deviceNameAlert = new Alert(Alert.AlertType.WARNING);
+            deviceNameAlert.setTitle("Warning");
+            deviceNameAlert.setHeaderText("Warning");
+            deviceNameAlert.setContentText("You are using ${Name} variable but your device does not have a name yet. Maybe you forgot to save it or did not select it in the list first?");
+            deviceNameAlert.showAndWait();
+        }
         if (!boardConfigField.isDisabled()) {
             builder.setBoardConfig(boardConfigField.getText());
         }

--- a/src/main/java/airsquared/blobsaver/app/TSS.java
+++ b/src/main/java/airsquared/blobsaver/app/TSS.java
@@ -51,6 +51,7 @@ public class TSS extends Task<String> {
     private static final Pattern ipswURLPattern = Pattern.compile("(https?://|file:/).*\\.(ipsw|plist)");
     private static final Pattern versionPattern = Pattern.compile("[0-9]+\\.[0-9]+\\.?[0-9]*(?<!\\.)");
 
+    private final String name;
     private final String deviceIdentifier;
     private final String ecid;
     private final String savePath;
@@ -68,7 +69,8 @@ public class TSS extends Task<String> {
     /**
      * Private constructor; use {@link TSS.Builder} instead
      */
-    private TSS(String deviceIdentifier, String ecid, String savePath, String boardConfig, boolean includeBetas, String manualVersion, String manualIpswURL, String apnonce, String generator, boolean saveToTSSSaver, boolean saveToSHSHHost) {
+    private TSS(String name, String deviceIdentifier, String ecid, String savePath, String boardConfig, boolean includeBetas, String manualVersion, String manualIpswURL, String apnonce, String generator, boolean saveToTSSSaver, boolean saveToSHSHHost) {
+        this.name = name;
         this.deviceIdentifier = deviceIdentifier;
         this.ecid = ecid;
         this.boardConfig = boardConfig;
@@ -189,7 +191,8 @@ public class TSS extends Task<String> {
         if (!input.contains("${")) return input;
         String template = input;
 
-        var variables = Map.of("${DeviceIdentifier}", deviceIdentifier,
+        var variables = Map.of("${Name}", Utils.defIfNull(name, "UnknownName"),
+                            "${DeviceIdentifier}", deviceIdentifier,
                             "${BoardConfig}", getBoardConfig(),
                             "${APNonce}", Utils.defIfNull(apnonce, "UnknownAPNonce"),
                             "${Generator}", Utils.defIfNull(generator, "UnknownGenerator"),
@@ -382,9 +385,13 @@ public class TSS extends Task<String> {
 
     @SuppressWarnings("UnusedReturnValue")
     public static class Builder {
-        private String device, ecid, savePath, boardConfig, manualVersion, manualIpswURL, apnonce, generator;
+        private String name, device, ecid, savePath, boardConfig, manualVersion, manualIpswURL, apnonce, generator;
         private boolean includeBetas, saveToTSSSaver, saveToSHSHHost;
 
+        public Builder setName(String name) {
+            this.name = name;
+            return this;
+        }
         public Builder setDevice(String device) {
             this.device = device;
             return this;
@@ -443,7 +450,8 @@ public class TSS extends Task<String> {
         }
 
         public TSS build() {
-            return new TSS(Objects.requireNonNull(device, "Device"),
+            return new TSS(name,
+                    Objects.requireNonNull(device, "Device"),
                     Objects.requireNonNull(ecid, "ECID"),
                     Objects.requireNonNull(savePath, "Save Path"),
                     boardConfig, includeBetas, manualVersion, manualIpswURL, apnonce, generator, saveToTSSSaver, saveToSHSHHost);


### PR DESCRIPTION
I'm using blobsaver with a lot of different devices (awesome project BTW :). The saved blobs can currently only be uniquely identified by the ECID, Generator or APNonce, none of which are easy to remember when working with multiple different devices. IMO it would be easier to save the blobs into a subdirectory with a name one can specify, i.e. the "saved device" name.

With the current changes this only works in CLI mode for imported/saved devices when requesting in background (my use-case). 

However if you want I can add further changes to make it possible in the GUI as well:
I propose a new "Name" field in the GUI, possibly above the ECID field. This would make the "Name Device" popup obsolete (at least when a name is already given). Then when building the TSS object the Name would be accessible in Controller.java:656 (createTSS).